### PR TITLE
Update 04_FIRST_SETTINGS.md (2 lines are a bit wrong)

### DIFF
--- a/04_FIRST_SETTINGS.md
+++ b/04_FIRST_SETTINGS.md
@@ -124,8 +124,8 @@ mkdir project/srcs/requirements/nginx/conf
 touch project/srcs/requirements/nginx/conf/nginx.conf
 mkdir project/srcs/requirements/nginx/tools
 touch project/srcs/requirements/nginx/Dockerfile
-echo ".git" > project/srcs/requirements/mariadb/.dockerignore
-echo ".env" >> project/srcs/requirements/mariadb/.dockerignore
+echo ".git" > project/srcs/requirements/nginx/.dockerignore
+echo ".env" >> project/srcs/requirements/nginx/.dockerignore
 mkdir project/srcs/requirements/tools
 mkdir project/srcs/requirements/wordpress
 mkdir project/srcs/requirements/wordpress/conf


### PR DESCRIPTION
the bash script for creating the directories has 2 lines wrong, when creating the folders and files for nginx, it puts the .dockerignore inside mariadb
